### PR TITLE
Fix animación de stack al pulsar filtro y volver a animar, se elimina ArrowIcon para pantallas menores de 600px

### DIFF
--- a/src/components/StackCard.astro
+++ b/src/components/StackCard.astro
@@ -2,8 +2,8 @@
 const { name, icon, classLiName, className } = Astro.props;
 ---
 
-<li class={`flex-nowrap ${classLiName} transition-all duration-300 transform`}>
-  <div class={`${className} flex items-center justify-center bg-white text-dark border-2 border-gray-200 hover:border-secondary transition-all py-1.5 duration-300 hover:shadow-md gap-2 mt-1 w-22 h-22 md:w-30 md:h-30 flex-col rounded-3xl md:hover:scale-105`}>
+<li class={`flex-nowrap ${classLiName}`}>
+  <div class={`${className} flex items-center justify-center bg-white text-dark border-2 border-gray-200 hover:border-secondary transition-all py-1.5 duration-300 hover:shadow-md w-22 h-22 md:w-30 md:h-30 flex-col rounded-3xl md:hover:scale-105`}>
       <img
           src={`../iconos/${icon}.svg`}
           alt={icon}

--- a/src/components/svg/ArrowIcon.astro
+++ b/src/components/svg/ArrowIcon.astro
@@ -10,7 +10,7 @@
     viewBox="0 0 24 24" 
     stroke-width="1.5" 
     stroke="currentColor" 
-    class="size-10 animate-bounce cursor-pointer"
+    class="hidden [@media(min-height:600px)]:block size-10 animate-bounce cursor-pointer"
     >
     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
     </svg>

--- a/src/components/svg/GitIcon.astro
+++ b/src/components/svg/GitIcon.astro
@@ -2,7 +2,7 @@
 const { className } = Astro.props;
 ---
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class=`lucide lucide-github-icon lucide-github ${className}`>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class=`lucide lucide-github-icon lucide-github ${className}`>
     <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>
     <path d="M9 18c-4.51 2-5-2-7-2"/>
 </svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,11 +12,11 @@ import Experience from '../sections/Experience.astro';
 
 <Layout>
     <main class="px-5 flex flex-col items-center w-full z-20 max-w-full">
-        <Section id="hero" class="py-20 md:py-40 flex flex-col justify-center items-center min-h-screen">
+        <Section id="hero" class="py-20 md:py-40 flex flex-col justify-center items-center min-h-[100dvh]">
             <Hero >
                 <slot />
             </Hero >
-            <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2">
+            <div class="absolute bottom-5 left-1/2 transform -translate-x-1/2">
                 <ArrowIcon alt="Flecha para hacer scroll a la sección de abajo" />
             </div>
         </Section>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -28,7 +28,7 @@
 
     <div>
         <h1 class="font-mono text-2xl md:text-3xl font-thin">whoami <br> <span class="text-4xl md:text-5xl font-thin mb-2 [&>strong]:font-bold">Cristina Malmierca</span></h1>
-        <h2 class="text-xl md:text-2xl font-bold mb-4 bg-linear-to-r from-secondary via-green-500 to-emerald-500 inline-block text-transparent bg-clip-text">&lt; Full-stack web Developer /&gt;</h2>
+        <h2 class="text-xl md:text-2xl font-bold mb-4 bg-linear-to-r from-secondary via-green-500 to-emerald-500 inline-block text-transparent bg-clip-text">&lt; Full-stack web<br class="md:hidden"> Developer &gt;</h2>
     </div>
 
     <div>

--- a/src/sections/Stack.astro
+++ b/src/sections/Stack.astro
@@ -43,12 +43,12 @@ import { Icon } from 'astro-icon/components';
 
 
     <div class="w-full overflow-hidden">
-        <ul id="stacklist" class="flex py-2 md:py-4 gap-4 justify-center flex-nowrap min-w-max animate-scroll transition-all duration-700 ease-out">
+        <ul id="stacklist" class="flex py-2 md:py-4 gap-4 justify-center flex-nowrap min-w-max animate-scroll">
             {[...STACKITEMS].map(item => (
-                <StackCard name={item.name} icon={item.icon} classLiName={`scroll-1 stack-item ${item.category} opacity-100 scale-100 transition-all duration-300 ease-in-out`} />
+                <StackCard name={item.name} icon={item.icon} classLiName={`scroll-1 stack-item ${item.category} opacity-100 scale-100`} />
             ))}
             {[...STACKITEMS].map(item => (
-                <StackCard name={item.name} icon={item.icon} classLiName={`scroll-2 stack-item hidden block transition-all duration-300 ease-in-out opacity-100 scale-100 ${item.category}`} />
+                <StackCard name={item.name} icon={item.icon} classLiName={`scroll-2 stack-item opacity-100 scale-100 ${item.category}`} />
             ))}
         </ul>
     </div>
@@ -67,6 +67,7 @@ import { Icon } from 'astro-icon/components';
     const stacklist: HTMLElement | null = document.getElementById('stacklist');
     const cards: HTMLCollection = document.getElementsByClassName('scroll-1');
     const cardsScroll: HTMLCollection = document.getElementsByClassName('scroll-2');
+    const stackContainer: HTMLElement | null = document.getElementById('stack-container');
 
         Array.from(links).forEach((link) => {
             link.addEventListener('click', () => {
@@ -127,6 +128,7 @@ import { Icon } from 'astro-icon/components';
 
                     
                     Array.from(cardsScroll).forEach((card) => {
+                        card.classList.remove('hidden');
                         card.classList.add('block');
                     });
                 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,14 +12,14 @@
     --font-mono: 'JetBrains Mono', monospace;
     --bg-primary: #F9FAFB;
     --bg-dark: #000000;
-    --animate-scroll: scroll 45s linear infinite;
+    --animate-scroll: scroll 40s linear infinite;
 
     @keyframes scroll {
         0% {
             transform: translateX(0); 
         }
         100% {
-             transform: translateX(calc(-50%));
+             transform: translateX(-50%);
         }
     }
 }
@@ -38,7 +38,7 @@ html, body {
     margin: 0;
     padding: 0;
     width: 100%;
-    min-height: 100vh;
+    min-height: 100dvh;
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
- Se corrige animación stack ya que al pulsar filtro y volver a animar, se cambiaba el tamaño total del div entonces se animaba más lento
- Se elimina ArroIcon en pantallas menos de 600px 